### PR TITLE
Add versionScheme & MiMa

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -77,3 +77,18 @@ jobs:
           key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
       - name: Run scapegoat
         run: sbt scapegoat
+
+  mima:
+    name: Report Binary Issues
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache SBT & ivy cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.ivy2/cache
+            ~/.sbt
+          key: ${{ runner.os }}-sbt-ivy-cache-${{ hashFiles('**/build.sbt') }}-${{ hashFiles('**/plugins.sbt') }}-${{ hashFiles('**/build.properties') }}
+      - name: Run mima
+        run: sbt mimaReportBinaryIssues

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This is a wrapper around the akka-http-client that adds
 * logging
 * AWS request signing
 
-![Build & Test](https://github.com/moia-dev/scala-http-client/workflows/Build%20&%20Test/badge.svg)
+![Build & Test](https://github.com/moia-oss/scala-http-client/workflows/Build%20&%20Test/badge.svg)
 [![Scala 2.13](https://img.shields.io/maven-central/v/io.moia/scala-http-client_2.13.svg)](https://search.maven.org/search?q=scala-http-client_2.13)
 
 ## Usage
@@ -149,7 +149,7 @@ See [HeaderExample.scala](/src/it/scala/io/moia/scalaHttpClient/HeaderExample.sc
 
 ## Publishing
 
-[Tag](https://github.com/moia-dev/scala-http-client/tags) the new version (e.g. `v3.0.0`) and push the tags (`git push origin --tags`).
+[Tag](https://github.com/moia-oss/scala-http-client/tags) the new version (e.g. `v3.0.0`) and push the tags (`git push origin --tags`).
 
 You need a [public GPG key](https://www.scala-sbt.org/release/docs/Using-Sonatype.html) with your MOIA email and an account on https://oss.sonatype.org that can [access](https://issues.sonatype.org/browse/OSSRH-52948) the `io.moia` group.
 
@@ -160,4 +160,4 @@ sbt:scala-http-client> +publishSigned
 
 Then head to https://oss.sonatype.org/#stagingRepositories, select the repository, `Close` and then `Release` it.
 
-Afterwards, add the release to [GitHub](https://github.com/moia-dev/scala-http-client/releases).
+Afterwards, add the release to [GitHub](https://github.com/moia-oss/scala-http-client/releases).

--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,7 @@ lazy val root = (project in file("."))
     homepage := Some(url("https://github.com/moia-dev/scala-http-client")),
     scalaVersion := "2.13.4",
     crossScalaVersions := List("2.13.4", "2.12.13"),
+    versionScheme := Some("early-semver"),
     scalacOptions ++= {
       CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, 12)) => scalacOptions_2_12

--- a/build.sbt
+++ b/build.sbt
@@ -3,8 +3,8 @@ lazy val root = (project in file("."))
     name := "scala-http-client",
     organization := "io.moia",
     licenses += ("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0")),
-    scmInfo := Some(ScmInfo(url("https://github.com/moia-dev/scala-http-client"), "scm:git@github.com:moia-dev/scala-http-client.git")),
-    homepage := Some(url("https://github.com/moia-dev/scala-http-client")),
+    scmInfo := Some(ScmInfo(url("https://github.com/moia-oss/scala-http-client"), "scm:git@github.com:moia-oss/scala-http-client.git")),
+    homepage := Some(url("https://github.com/moia-oss/scala-http-client")),
     scalaVersion := "2.13.4",
     crossScalaVersions := List("2.13.4", "2.12.13"),
     versionScheme := Some("early-semver"),
@@ -100,7 +100,7 @@ lazy val sonatypeSettings = {
     publishTo := sonatypePublishTo.value,
     sonatypeProfileName := organization.value,
     publishMavenStyle := true,
-    sonatypeProjectHosting := Some(GitHubHosting("moia-dev", "scala-http-client", "oss-support@moia.io")),
+    sonatypeProjectHosting := Some(GitHubHosting("moia-oss", "scala-http-client", "oss-support@moia.io")),
     credentials += Credentials(Path.userHome / ".sbt" / "sonatype_credential")
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -29,6 +29,7 @@ lazy val root = (project in file("."))
     GitVersioning,
     GitBranchPrompt
   )
+  .settings(mimaSettings)
 
 val akkaVersion     = "2.6.12"
 val akkaHttpVersion = "10.2.3"
@@ -117,4 +118,8 @@ lazy val sbtGitSettings = Seq(
     case sbtVersionRegex(v, s)          => Some(s"$v-$s-SNAPSHOT")
     case _                              => None
   }
+)
+
+lazy val mimaSettings = Seq(
+  mimaPreviousArtifacts := Set("io.moia" %% "scala-http-client" % "4.0.0")
 )

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -14,3 +14,6 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.5")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
+
+// sbt> mimaReportBinaryIssues
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")


### PR DESCRIPTION
- Adds `versionScheme: early-semver` from sbt `1.4.0` [which will be enforced with the upcoming sbt](https://scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html) `1.5.0` for eviction errors
- Adds `mimaReportBinaryIssues` plugin to GitHub Actions to ensure sane versioning
- ~Updates to new `moia-oss`~ moved to #158 

I think we don't need to release this as a new version. Maybe as patch release.

Background for `versionScheme`: https://www.scala-lang.org/blog/2021/02/16/preventing-version-conflicts-with-versionscheme.html